### PR TITLE
Feature: Register AAS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2462,9 +2462,9 @@
       },
       "dependencies": {
         "json5": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+          "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  apiKey: "ApiKeyDefaultValue"
+  apiKey: "password"
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,7 @@
 
 export const environment = {
   production: false,
-  apiKey: "ApiKeyDefaultValue"
+  apiKey: "password"
 };
 
 /*

--- a/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.html
+++ b/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.html
@@ -13,7 +13,7 @@
   </div>
 
   <mat-card
-    *ngIf="selfDescriptionContainer.selfDescriptions | async as selfDescriptions; else no_self_description">
+    *ngIf="selfDescriptionContainer?.selfDescriptions | async as selfDescriptions; else no_self_description">
     <mat-card-content *ngFor="let selfDescription of selfDescriptions" class="self-description-card">
       <div class="aas-element-div" mat-line>AAS</div>
       <mat-expansion-panel>

--- a/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.html
+++ b/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.html
@@ -1,19 +1,44 @@
 <div id="wrapper">
-  <div>
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
+      <mat-panel-title>Register an AAS service by URL or by file</mat-panel-title>
+    </mat-expansion-panel-header>
+
     <mat-form-field class="search-form-field" color="accent">
-      <mat-label>Register AAS by URL</mat-label>
-      <input #aasUrl matInput>
-      <button (click)="aasUrl.value=''" *ngIf="aasUrl.value" mat-icon-button matSuffix>
+        <mat-label>URL</mat-label>
+        <input #aasUrl type="url" matInput>
+        <button (click)="aasUrl.value=''" *ngIf="aasUrl.value" mat-icon-button matSuffix>
+          <mat-icon>close</mat-icon>
+        </button>
+        <button (click)="registerAASByUrl(aasUrl.value)" *ngIf="aasUrl.value" mat-icon-button matSuffix>
+          <mat-icon>add</mat-icon>
+        </button>
+      </mat-form-field>
+      <br>
+      <mat-form-field class="search-form-field" color="accent">
+        <mat-label>Environment Path</mat-label><input #aasFilePath matInput>
+      </mat-form-field>
+      <mat-form-field class="search-form-field" color="accent">
+        <mat-label>Configuration File Path</mat-label><input #aasConfig matInput>
+      </mat-form-field>
+      <mat-form-field class="number-form-field" color="accent">
+        <mat-label>AAS Service Port</mat-label><input #aasPort type="number" min="0" max="65535" matInput>
+      </mat-form-field>
+
+      <button (click)="aasFilePath.value = ''; aasPort.value = ''; aasConfig.value"
+        *ngIf="aasFilePath.value || aasPort.value || aasConfig.value" mat-icon-button matSuffix>
         <mat-icon>close</mat-icon>
       </button>
-      <button (click)="registerAAS(aasUrl.value)" *ngIf="aasUrl.value" mat-icon-button matSuffix>
+
+      <button
+        (click)="registerAASByFile(aasFilePath.value, aasPort.value, aasConfig.value); aasFilePath.value = ''; aasPort.value = ''"
+        *ngIf="aasPort.value && aasFilePath.value || aasConfig.value && aasFilePath.value" mat-icon-button matSuffix>
         <mat-icon>add</mat-icon>
       </button>
-    </mat-form-field>
-  </div>
 
-  <mat-card
-    *ngIf="selfDescriptionContainer?.selfDescriptions | async as selfDescriptions; else no_self_description">
+  </mat-expansion-panel>
+
+  <mat-card *ngIf="selfDescriptionContainer?.selfDescriptions | async as selfDescriptions; else no_self_description">
     <mat-card-content *ngFor="let selfDescription of selfDescriptions" class="self-description-card">
       <div class="aas-element-div" mat-line>AAS</div>
       <mat-expansion-panel>

--- a/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.html
+++ b/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.html
@@ -1,5 +1,19 @@
 <div id="wrapper">
-  <mat-card *ngIf="selfDescriptionContainer$?.selfDescriptions | async as selfDescriptions; else no_self_description">
+  <div>
+    <mat-form-field class="search-form-field" color="accent">
+      <mat-label>Register AAS by URL</mat-label>
+      <input #aasUrl matInput>
+      <button (click)="aasUrl.value=''" *ngIf="aasUrl.value" mat-icon-button matSuffix>
+        <mat-icon>close</mat-icon>
+      </button>
+      <button (click)="registerAAS(aasUrl.value)" *ngIf="aasUrl.value" mat-icon-button matSuffix>
+        <mat-icon>add</mat-icon>
+      </button>
+    </mat-form-field>
+  </div>
+
+  <mat-card
+    *ngIf="selfDescriptionContainer.selfDescriptions | async as selfDescriptions; else no_self_description">
     <mat-card-content *ngFor="let selfDescription of selfDescriptions" class="self-description-card">
       <div class="aas-element-div" mat-line>AAS</div>
       <mat-expansion-panel>

--- a/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.scss
+++ b/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.scss
@@ -31,7 +31,7 @@
 }
 
 .mat-list-base.inline-list {
-    display: flex;
+  display: flex;
 }
 
 .aas-submodel-element-card {
@@ -64,8 +64,15 @@
 }
 
 .search-form-field {
-  min-width: 200px;
+  padding-left: 5px;
+  min-width: 150px;
   width: 30%;
+}
+
+.number-form-field {
+  padding-left: 5px;
+  min-width: 20px;
+  width: 10%;
 }
 
 .card-actions {
@@ -81,4 +88,8 @@
 mat-paginator {
   display: inline-block;
   background-color: transparent;
+}
+
+.mat-expansion-panel-body {
+  margin-left: 5px;
 }

--- a/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.ts
+++ b/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.ts
@@ -32,7 +32,7 @@ export class OwnSelfDescriptionBrowserComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.selfDescriptionService.addSelfDescriptionForUrl(this.provider, this.defaultHeaders);
+    this.selfDescriptionService.readSelfDescriptions(this.provider, this.defaultHeaders);
     var allSelfDescriptions = this.selfDescriptionService.getAllSelfDescriptions();
     this.selfDescriptionContainer$ = allSelfDescriptions.values().next().value;
   }

--- a/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.ts
+++ b/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.ts
@@ -34,7 +34,6 @@ export class OwnSelfDescriptionBrowserComponent implements OnInit {
     this.updateSelfDescriptionContainer()
   }
 
-
   async editContract(element: IdsAssetElement) {
     // TODO see asset-editor-dialog
     alert("Navigating to contract page for asset " + element.idsContractId + "... ");
@@ -48,12 +47,15 @@ export class OwnSelfDescriptionBrowserComponent implements OnInit {
   }
 
   async registerAASByFile(aasPath: string, aasPort: string, aasConfig: string) {
-    if (!aasConfig) {
-      this._registerAASByFileUsingConfig(aasPath, aasConfig);
+    var sanitizedPath = aasPath.replace(/\\/g, "/");
+    var sanitizedConfigPath = aasConfig.replace(/\\/g, "/");
+    console.log(sanitizedPath, sanitizedConfigPath)
+    if (aasConfig && aasConfig !== '') {
+      this._registerAASByFileUsingConfig(sanitizedPath, sanitizedConfigPath);
       return;
     }
     if (new Number(aasPort)) {
-      this._registerAASByFileUsingPort(aasPath, new Number(aasPort));
+      this._registerAASByFileUsingPort(sanitizedPath, new Number(aasPort));
     }
   }
 

--- a/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.ts
+++ b/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.ts
@@ -1,11 +1,12 @@
-import { HttpClient, HttpHeaders, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Component, Inject, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-import { EdcApiKeyInterceptor } from 'src/modules/app/edc.apikey.interceptor';
 import { IdsAssetElement } from '../../models/ids-asset-element';
 import { SelfDescriptionContainer } from '../../models/self-description-container';
 import { SelfDescriptionBrowserService } from '../../services/self-description-browser.service';
+import { SelfDescriptionRegistrationService } from '../../services/self-description-registration.service';
 import { CONNECTOR_SELF_DESCRIPTION_API } from '../../variables';
+
 
 @Component({
   selector: 'MyAAS',
@@ -14,27 +15,21 @@ import { CONNECTOR_SELF_DESCRIPTION_API } from '../../variables';
 })
 export class OwnSelfDescriptionBrowserComponent implements OnInit {
 
-  public defaultHeaders = new HttpHeaders({ 'X-Api-Key': this.httpInterceptor.apiKey });
-
-  selfDescriptionContainer$?: SelfDescriptionContainer;
+  selfDescriptionContainer?: SelfDescriptionContainer;
   notFound: boolean = false;
   provider: URL;
   private selfDescriptionService: SelfDescriptionBrowserService;
 
-  constructor(httpClient: HttpClient,
+  constructor(private selfDescriptionRegistrationService: SelfDescriptionRegistrationService,
+    httpClient: HttpClient,
     @Inject(CONNECTOR_SELF_DESCRIPTION_API) provider: URL,
-    @Inject(HTTP_INTERCEPTORS) private httpInterceptor: EdcApiKeyInterceptor,
     private router: Router) {
-
     this.provider = provider;
-
     this.selfDescriptionService = new SelfDescriptionBrowserService(httpClient);
   }
 
   ngOnInit(): void {
-    this.selfDescriptionService.readSelfDescriptions(this.provider, this.defaultHeaders);
-    var allSelfDescriptions = this.selfDescriptionService.getAllSelfDescriptions();
-    this.selfDescriptionContainer$ = allSelfDescriptions.values().next().value;
+    this.updateSelfDescriptionContainer()
   }
 
   async editContract(element: IdsAssetElement) {
@@ -43,9 +38,23 @@ export class OwnSelfDescriptionBrowserComponent implements OnInit {
     this.reroute("/contract-definitions");
   }
 
+  async registerAAS(aas: string) {
+    var response = this.selfDescriptionRegistrationService.registerUrl(
+      new URL(new URL(this.provider).protocol + "//" + new URL(this.provider).host),
+      new URL(aas));
+
+    response.forEach(_ => this.updateSelfDescriptionContainer());
+  }
+
+  updateSelfDescriptionContainer() {
+    this.selfDescriptionService.readSelfDescriptions(this.provider);
+    var allSelfDescriptions = this.selfDescriptionService.getAllSelfDescriptions();
+    this.selfDescriptionContainer = allSelfDescriptions.values().next().value;
+  }
+
   reroute(site: string) {
     this.router.navigateByUrl(site);
-    // TODO how do i pass element info to other sites?
+    // TODO how do you pass element info to other sites?
   }
 }
 

--- a/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.ts
+++ b/src/modules/edc4aas/components/own-self-description-browser/own-self-description-browser.component.ts
@@ -41,10 +41,32 @@ export class OwnSelfDescriptionBrowserComponent implements OnInit {
     this.reroute("/contract-definitions");
   }
 
-  async registerAAS(aas: string) {
+  async registerAASByUrl(aas: string) {
     var sanitized = aas.toLowerCase().replace(" ", "%20");
     this.selfDescriptionRegistrationService.registerUrl(this.providerNoPath, new URL(sanitized));
     this.updateSelfDescriptionContainer();
+  }
+
+  async registerAASByFile(aasPath: string, aasPort: string, aasConfig: string) {
+    if (!aasConfig) {
+      this._registerAASByFileUsingConfig(aasPath, aasConfig);
+      return;
+    }
+    if (new Number(aasPort)) {
+      this._registerAASByFileUsingPort(aasPath, new Number(aasPort));
+    }
+  }
+
+  private _registerAASByFileUsingConfig(aasPath: string, aasConfig: string) {
+    this.selfDescriptionRegistrationService.registerFileWithConfig(this.providerNoPath, aasPath, aasConfig);
+  }
+
+  private _registerAASByFileUsingPort(aasPath: string, aasPort: Number) {
+    if (aasPort > 65536 || aasPort < 0) {
+      alert("Port not in [0,2^16)");
+      return;
+    }
+    this.selfDescriptionRegistrationService.registerFileWithPort(this.providerNoPath, aasPath, aasPort);
   }
 
   async updateSelfDescriptionContainer() {

--- a/src/modules/edc4aas/components/self-description-browser/self-description-browser.component.html
+++ b/src/modules/edc4aas/components/self-description-browser/self-description-browser.component.html
@@ -19,7 +19,7 @@
 
       <mat-card *ngIf="selfDescriptionContainer?.selfDescriptions | async as selfDescriptions">
         <mat-card-header class="self-descriptions-header">
-          <mat-card-title class="self-description-title">Self Description of {{selfDescriptionContainer.provider}}
+          <mat-card-title class="self-description-title">AAS(s) of {{selfDescriptionContainer.provider}}
           </mat-card-title>
           <button (click)="onDelete(selfDescriptionContainer)" mat-icon-button matSuffix>
             <mat-icon>close</mat-icon>

--- a/src/modules/edc4aas/components/self-description-browser/self-description-browser.component.ts
+++ b/src/modules/edc4aas/components/self-description-browser/self-description-browser.component.ts
@@ -1,8 +1,7 @@
-import { HttpClient, HttpHeaders, HTTP_INTERCEPTORS } from '@angular/common/http';
-import { Component, Inject, OnInit } from '@angular/core';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';
-import { EdcApiKeyInterceptor } from 'src/modules/app/edc.apikey.interceptor';
 import { IdsAssetElement } from '../../models/ids-asset-element';
 import { SelfDescriptionContainer } from '../../models/self-description-container';
 import { SelfDescriptionBrowserService } from '../../services/self-description-browser.service';
@@ -14,15 +13,12 @@ import { SelfDescriptionBrowserService } from '../../services/self-description-b
 })
 export class SelfDescriptionBrowserComponent implements OnInit {
 
-  public defaultHeaders = new HttpHeaders({ 'X-Api-Key': this.httpInterceptor.apiKey });
-
   selfDescriptionContainers$: Set<SelfDescriptionContainer>;
   fetch$ = new BehaviorSubject(null);
   searchText = '';
 
   constructor(private selfDescriptionService: SelfDescriptionBrowserService,
     protected httpClient: HttpClient,
-    @Inject(HTTP_INTERCEPTORS) private httpInterceptor: EdcApiKeyInterceptor,
     private router: Router) {
     this.selfDescriptionContainers$ = selfDescriptionService.getAllSelfDescriptions();
   }
@@ -31,7 +27,7 @@ export class SelfDescriptionBrowserComponent implements OnInit {
 
   async onSearch() {
     if (await this.checkLink(`${this.searchText}`)) {
-      this.selfDescriptionService.readSelfDescriptions(new URL(this.searchText), this.defaultHeaders);
+      this.selfDescriptionService.readSelfDescriptions(new URL(this.searchText));
     } else alert("URL not responding");
   }
 

--- a/src/modules/edc4aas/components/self-description-browser/self-description-browser.component.ts
+++ b/src/modules/edc4aas/components/self-description-browser/self-description-browser.component.ts
@@ -26,8 +26,10 @@ export class SelfDescriptionBrowserComponent implements OnInit {
   ngOnInit(): void { }
 
   async onSearch() {
-    if (await this.checkLink(`${this.searchText}`)) {
-      this.selfDescriptionService.readSelfDescriptions(new URL(this.searchText));
+    var sanitized = this.searchText.toLowerCase().replace(" ", "%20");
+
+    if (await this.checkLink(`${sanitized}`)) {
+      this.selfDescriptionService.readSelfDescriptions(new URL(sanitized));
     } else alert("URL not responding");
   }
 

--- a/src/modules/edc4aas/components/self-description-browser/self-description-browser.component.ts
+++ b/src/modules/edc4aas/components/self-description-browser/self-description-browser.component.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs';

--- a/src/modules/edc4aas/components/self-description-browser/self-description-browser.component.ts
+++ b/src/modules/edc4aas/components/self-description-browser/self-description-browser.component.ts
@@ -31,7 +31,7 @@ export class SelfDescriptionBrowserComponent implements OnInit {
 
   async onSearch() {
     if (await this.checkLink(`${this.searchText}`)) {
-      this.selfDescriptionService.addSelfDescriptionForUrl(new URL(this.searchText), this.defaultHeaders);
+      this.selfDescriptionService.readSelfDescriptions(new URL(this.searchText), this.defaultHeaders);
     } else alert("URL not responding");
   }
 

--- a/src/modules/edc4aas/services/self-description-browser.service.ts
+++ b/src/modules/edc4aas/services/self-description-browser.service.ts
@@ -24,12 +24,11 @@ export class SelfDescriptionBrowserService {
     return this.selfDescriptionContainers$;
   }
 
-  public readSelfDescriptions(url: URL, _headers: HttpHeaders) {
+  public readSelfDescriptions(url: URL) {
     const selfDescriptions = this.fetch$
       .pipe(
         switchMap(() => {
-          return this.httpClient.get<Array<SelfDescription>>(url.toString(),
-            { headers: _headers });
+          return this.httpClient.get<Array<SelfDescription>>(url.toString());
         }));
 
     this.selfDescriptionContainers$.add(new SelfDescriptionContainer(selfDescriptions, url));

--- a/src/modules/edc4aas/services/self-description-browser.service.ts
+++ b/src/modules/edc4aas/services/self-description-browser.service.ts
@@ -24,7 +24,7 @@ export class SelfDescriptionBrowserService {
     return this.selfDescriptionContainers$;
   }
 
-  public addSelfDescriptionForUrl(url: URL, _headers: HttpHeaders) {
+  public readSelfDescriptions(url: URL, _headers: HttpHeaders) {
     const selfDescriptions = this.fetch$
       .pipe(
         switchMap(() => {

--- a/src/modules/edc4aas/services/self-description-registration.service.ts
+++ b/src/modules/edc4aas/services/self-description-registration.service.ts
@@ -33,7 +33,7 @@ export class SelfDescriptionRegistrationService {
    */
   registerFileWithPort(edcUrl: URL, aasPath: string, aasPort: Number) {
     var requestUrl = edcUrl + "api/environment?environment=" + aasPath + "&port=" + aasPort;
-    return this.httpClient.post(requestUrl, null);
+    return this.httpClient.post(requestUrl, null).subscribe((_) => console.log("Sent post"));
   }
 
   /**
@@ -47,6 +47,6 @@ export class SelfDescriptionRegistrationService {
    */
   registerFileWithConfig(edcUrl: URL, aasPath: string, aasConfigFile: string) {
     var requestUrl = edcUrl + "api/environment?environment=" + aasPath + "&config=" + aasConfigFile;
-    return this.httpClient.post(requestUrl, null);
+    return this.httpClient.post(requestUrl, null).subscribe((_) => console.log("Sent post"));
   }
 }

--- a/src/modules/edc4aas/services/self-description-registration.service.ts
+++ b/src/modules/edc4aas/services/self-description-registration.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 
 
@@ -12,15 +12,41 @@ export class SelfDescriptionRegistrationService {
   constructor(private httpClient: HttpClient) { }
 
   /**
-   * Register a standalone AAS service (e.g., FA³ST) at the EDC.
-   *
-   * @param edcUrl Clean URL of EDC (only protocol://hostname:port)
-   * @param aasUrl Base URL of the AAS Service to be added
-   * @param _headers Authentication keys if needed
-   */
+  * Register a standalone AAS service (e.g., FA³ST) at the EDC.
+  *
+  * @param edcUrl Clean URL of EDC (only protocol://hostname:port)
+  * @param aasUrl Base URL of the AAS Service to be added
+  * @returns HTTP POST response
+  */
   public registerUrl(edcUrl: URL, aasUrl: URL) {
     var requestUrl = edcUrl + "api/client?url=" + aasUrl;
     return this.httpClient.post(requestUrl, null);
   }
 
+  /**
+   * Register an AAS service the EDC using an environment file.
+   *
+   * @param edcUrl Clean URL of EDC (only protocol://hostname:port)
+   * @param aasPath Path to AAS environment
+   * @param aasPort Port of new AAS service
+   * @returns HTTP POST response
+   */
+  registerFileWithPort(edcUrl: URL, aasPath: string, aasPort: Number) {
+    var requestUrl = edcUrl + "api/environment?environment=" + aasPath + "&port=" + aasPort;
+    return this.httpClient.post(requestUrl, null);
+  }
+
+  /**
+   * Register an AAS service the EDC using an environment file.
+   *
+   * @param edcUrl Clean URL of EDC (only protocol://hostname:port)
+   * @param aasPath Path to AAS environment
+   * @param aasConfigFile Config file for the AAS environment
+   * (see EDC4AAS Extension for supported config files)
+   * @returns HTTP POST response
+   */
+  registerFileWithConfig(edcUrl: URL, aasPath: string, aasConfigFile: string) {
+    var requestUrl = edcUrl + "api/environment?environment=" + aasPath + "&config=" + aasConfigFile;
+    return this.httpClient.post(requestUrl, null);
+  }
 }

--- a/src/modules/edc4aas/services/self-description-registration.service.ts
+++ b/src/modules/edc4aas/services/self-description-registration.service.ts
@@ -1,0 +1,26 @@
+import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+
+
+/**
+ * Combines several services that are used from the {@link SelfDescriptionBrowserComponent}
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class SelfDescriptionRegistrationService {
+  constructor(private httpClient: HttpClient) { }
+
+  /**
+   * Register a standalone AAS service (e.g., FA³ST) at the EDC.
+   *
+   * @param edcUrl Clean URL of EDC (only protocol://hostname:port)
+   * @param aasUrl Base URL of the AAS Service to be added
+   * @param _headers Authentication keys if needed
+   */
+  public registerUrl(edcUrl: URL, aasUrl: URL) {
+    var requestUrl = edcUrl + "api/client?url=" + aasUrl;
+    return this.httpClient.post(requestUrl, null);
+  }
+
+}

--- a/src/modules/edc4aas/services/self-description-registration.service.ts
+++ b/src/modules/edc4aas/services/self-description-registration.service.ts
@@ -20,7 +20,7 @@ export class SelfDescriptionRegistrationService {
   */
   public registerUrl(edcUrl: URL, aasUrl: URL) {
     var requestUrl = edcUrl + "api/client?url=" + aasUrl;
-    return this.httpClient.post(requestUrl, null);
+    return this.httpClient.post(requestUrl, null).subscribe((error) => console.log(error));
   }
 
   /**
@@ -33,7 +33,7 @@ export class SelfDescriptionRegistrationService {
    */
   registerFileWithPort(edcUrl: URL, aasPath: string, aasPort: Number) {
     var requestUrl = edcUrl + "api/environment?environment=" + aasPath + "&port=" + aasPort;
-    return this.httpClient.post(requestUrl, null).subscribe((_) => console.log("Sent post"));
+    return this.httpClient.post(requestUrl, null).subscribe((error) => console.log(error));;
   }
 
   /**
@@ -47,6 +47,6 @@ export class SelfDescriptionRegistrationService {
    */
   registerFileWithConfig(edcUrl: URL, aasPath: string, aasConfigFile: string) {
     var requestUrl = edcUrl + "api/environment?environment=" + aasPath + "&config=" + aasConfigFile;
-    return this.httpClient.post(requestUrl, null).subscribe((_) => console.log("Sent post"));
+    return this.httpClient.post(requestUrl, null).subscribe((error) => console.log(error));;
   }
 }


### PR DESCRIPTION
## What this PR changes/adds

Ability to (un)register standalone AAS / add AAS by file to the EDC's extension.

Also: Fixes error with new Api-Key storage location within the Dashboard
## Why it does that

Functionality

## Further notes

The extension does not provide an AAS's URL in the self description. For now, this information will not be shown in the Dashboard either.

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
