### PR TITLE
Fix: Non-errors shown as errors in message log

### DIFF
--- a/src/modules/edc4aas/components/publish-aas/publish-aas.component.ts
+++ b/src/modules/edc4aas/components/publish-aas/publish-aas.component.ts
@@ -71,7 +71,7 @@ export class PublishAASComponent {
   }
 
   private _registerAASByFileUsingPort(aasPath: string, aasPort: number) {
-    if (aasPort > 65536 || aasPort < 0) {
+    if (aasPort > 65535 || aasPort < 0) {
       alert("Port not in [0,2^16)");
       return;
     }

--- a/src/modules/edc4aas/services/self-description-registration.service.ts
+++ b/src/modules/edc4aas/services/self-description-registration.service.ts
@@ -20,7 +20,7 @@ export class SelfDescriptionRegistrationService {
   */
   public registerUrl(edcUrl: URL, aasUrl: URL) {
     var requestUrl = edcUrl + "/client?url=" + aasUrl;
-    return this.httpClient.post(requestUrl, null);
+    return this.httpClient.post(requestUrl, null, { responseType: 'text' });
   }
 
   /**
@@ -33,7 +33,7 @@ export class SelfDescriptionRegistrationService {
    */
   registerFileWithPort(edcUrl: URL, aasPath: string, aasPort: Number) {
     var requestUrl = edcUrl + "/environment?environment=" + aasPath + "&port=" + aasPort;
-    return this.httpClient.post(requestUrl, null);
+    return this.httpClient.post(requestUrl, null, { responseType: 'text' });
   }
 
   /**
@@ -47,6 +47,6 @@ export class SelfDescriptionRegistrationService {
    */
   registerFileWithConfig(edcUrl: URL, aasPath: string, aasConfigFile: string) {
     var requestUrl = edcUrl + "/environment?environment=" + aasPath + "&config=" + aasConfigFile;
-    return this.httpClient.post(requestUrl, null);
+    return this.httpClient.post(requestUrl, null, { responseType: 'text' });
   }
 }


### PR DESCRIPTION
## What this PR changes/adds

See title

## Why it does that

rxjs tries to parse responses as json by default. Responses are in 'text' format for the fixed requests

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
